### PR TITLE
cmake vcpkg changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option (CC_NO_CXX_STANDARD_FORCING "Disable forcing C++ standard to C++11 when n
 option (CC_NO_CCACHE "Disable use of ccache on UNIX systems")
 
 # Extra variables
-# CC_QT_DIR=dir - Directory of QT5 installation. Can be used to provide path to QT5 if
+# Qt5_DIR=dir - Directory of QT5 installation. Can be used to provide path to QT5 if
 #   differs from system default installation path.
 # CC_EXTERNALS_DIR - Directory where pull externals, defaults to 
 #   ${PROJECT_SOURCE_DIR}/externals
@@ -73,19 +73,13 @@ cc_compile(${warn_opt} ${static_runtime_opt} ${ccache_opt})
 
 set (COMMS_CHAMPION_LIB_NAME "comms_champion")
 
-if (NOT "${CC_QT_DIR}" STREQUAL "")
-    list (APPEND CMAKE_PREFIX_PATH ${CC_QT_DIR})
-    link_directories ("${CC_QT_DIR}/lib")
-    link_directories ("${CC_QT_DIR}/plugins/platforms")
-endif ()
-
 include(GNUInstallDirs)
 set (INSTALL_NAME "CommsChampion")
 set (LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
-set (BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+set (BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
 set (INC_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 set (PLUGIN_INSTALL_REL_DIR ${CMAKE_INSTALL_LIBDIR}/${INSTALL_NAME}/plugin)
-set (PLUGIN_INSTALL_DIR ${PLUGIN_INSTALL_REL_DIR})
+set (PLUGIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PLUGIN_INSTALL_REL_DIR})
 set (DATA_INSTALL_REL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/${INSTALL_NAME})
 set (DATA_INSTALL_DIR ${DATA_INSTALL_REL_DIR})
 set (DOC_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/doc)
@@ -160,9 +154,13 @@ endif ()
 
 add_subdirectory (demo)
 
-if (WIN32 AND CC_QT_DIR)
+if (WIN32)
+    find_package(Qt5 COMPONENTS Core REQUIRED)
+    get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+    get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+
     add_custom_target ("deploy_qt"
-        COMMAND ${CMAKE_COMMAND} -DCC_QT_DIR=${CC_QT_DIR}
+        COMMAND ${CMAKE_COMMAND} -DCC_QT_DIR=${_qt_bin_dir}
             -DCC_BIN_DIR=${BIN_INSTALL_DIR} -DCC_PLUGIN_DIR=${PLUGIN_INSTALL_DIR}
             -P ${PROJECT_SOURCE_DIR}/cmake/CC_DeployQt5Script.cmake
     )

--- a/cmake/CC_DeployQt5Script.cmake
+++ b/cmake/CC_DeployQt5Script.cmake
@@ -1,18 +1,15 @@
 # This script deploys Qt5 libraries on Windows.
 # 
 # Expected input variables
-# CC_QT_DIR - Directory of Qt5 installation
 # CC_BIN_DIR - Directory where all binaries are installed
 # CC_PLUGIN_DIR - Directory where all plugins are installed
 
 if (NOT WIN32)
     message (FATAL_ERROR "Qt5 deployment works only on Windows.")
 endif ()
-
 if ("${CC_QT_DIR}" STREQUAL "")
     message (FATAL_ERROR "Qt5 directory hasn't been provided.")
 endif()
-
 if ("${CC_BIN_DIR}" STREQUAL "")
     message (FATAL_ERROR "Directory of binaries hasn't been provided.")
 endif()
@@ -21,7 +18,9 @@ if ("${CC_PLUGIN_DIR}" STREQUAL "")
     message (FATAL_ERROR "Directory of plugins hasn't been provided.")
 endif()
 
-find_program (deploy_exe windeployqt PATHS ${CC_QT_DIR}/bin)
+
+message(STATUS ${CC_BIN_DIR})
+find_program(deploy_exe windeployqt HINTS "${CC_QT_DIR}")
 
 if (NOT deploy_exe)
     message (FATAL_ERROR "windeployqt.exe hasn't been found.")

--- a/cmake/CC_DeployQt5Script.cmake
+++ b/cmake/CC_DeployQt5Script.cmake
@@ -18,8 +18,6 @@ if ("${CC_PLUGIN_DIR}" STREQUAL "")
     message (FATAL_ERROR "Directory of plugins hasn't been provided.")
 endif()
 
-
-message(STATUS ${CC_BIN_DIR})
 find_program(deploy_exe windeployqt HINTS "${CC_QT_DIR}")
 
 if (NOT deploy_exe)

--- a/comms_champion/app/cc_dump/src/CMakeLists.txt
+++ b/comms_champion/app/cc_dump/src/CMakeLists.txt
@@ -31,7 +31,7 @@ endfunction ()
 
 ###########################################################
 
-find_package(Qt5Core)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 include_directories (
 #    ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/app/cc_view/CMakeLists.txt
+++ b/comms_champion/app/cc_view/CMakeLists.txt
@@ -1,22 +1,2 @@
 add_subdirectory (src)
 
-if (UNIX)
-    install(
-        PROGRAMS script/cc_view.sh
-        DESTINATION ${BIN_INSTALL_DIR}
-    )
-endif ()  
-
-if (WIN32 AND (NOT "${CC_QT_DIR}" STREQUAL ""))
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -DAPP_NAME=cc_view -DEXTRA_PATH=${CC_QT_DIR}\\bin
-            -DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}
-            -P ${PROJECT_SOURCE_DIR}/cmake/CC_GenWinAppStartBat.cmake
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    
-    install(
-        PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/cc_view.bat"
-        DESTINATION ${BIN_INSTALL_DIR}
-    )
-endif ()

--- a/comms_champion/app/cc_view/src/CMakeLists.txt
+++ b/comms_champion/app/cc_view/src/CMakeLists.txt
@@ -150,8 +150,7 @@ endfunction ()
 
 ###########################################################
 
-find_package(Qt5Widgets)
-find_package(Qt5Core)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/lib/src/CMakeLists.txt
+++ b/comms_champion/lib/src/CMakeLists.txt
@@ -84,21 +84,6 @@ function (lib_comms_champion)
 endfunction ()
 
 ###########################################################
-
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-
-if (WIN32)
-    find_library(QT5PLATFORMSUPPORT_REL Qt5PlatformSupport HINTS "${CC_QT_DIR}/lib")
-    find_library(QT5PLATFORMSUPPORT_DEB Qt5PlatformSupportd HINTS "${CC_QT_DIR}/lib")
-    set(QT5PLATFORMSUPPORT optimized ${QT5PLATFORMSUPPORT_REL} debug ${QT5PLATFORMSUPPORT_DEB})
-
-    if (NOT QT5PLATFORMSUPPORT)
-        set (QT5PLATFORMSUPPORT)
-    endif ()
-    
-    set (CC_PLATFORM_SPECIFIC ${QT5PLATFORMSUPPORT} Setupapi.lib Ws2_32.lib opengl32.lib imm32.lib winmm.lib)
-
-endif ()   
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 lib_comms_champion()

--- a/comms_champion/plugin/serial_socket/CMakeLists.txt
+++ b/comms_champion/plugin/serial_socket/CMakeLists.txt
@@ -60,9 +60,7 @@ endfunction()
 
 ######################################################################
 
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-find_package(Qt5SerialPort)
+find_package(Qt5 COMPONENTS Widgets SerialPort REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/plugin/tcp_socket/client/CMakeLists.txt
+++ b/comms_champion/plugin/tcp_socket/client/CMakeLists.txt
@@ -61,9 +61,7 @@ endfunction()
 
 ######################################################################
 
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/plugin/tcp_socket/proxy/CMakeLists.txt
+++ b/comms_champion/plugin/tcp_socket/proxy/CMakeLists.txt
@@ -61,9 +61,7 @@ endfunction()
 
 ######################################################################
 
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/plugin/tcp_socket/server/CMakeLists.txt
+++ b/comms_champion/plugin/tcp_socket/server/CMakeLists.txt
@@ -61,9 +61,7 @@ endfunction()
 
 ######################################################################
 
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/comms_champion/plugin/udp_socket/CMakeLists.txt
+++ b/comms_champion/plugin/udp_socket/CMakeLists.txt
@@ -61,9 +61,7 @@ endfunction()
 
 ######################################################################
 
-find_package(Qt5Core)
-find_package(Qt5Widgets)
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Widgets Network REQUIRED)
 
 include_directories (
     ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
These are mainly changes for vcpkg to make the whole qt finding process a bit more confortable.
To use this outside of vcpkg, just pass `cmake -DQt5_DIR=/path/to/qt/lib/cmake/Qt5`

I've added ${CMAKE_INSTALL_PREFIX} to `BIN_INSTALL_DIR` and `PLUGIN_INSTALL_DIR` since the ${CMAKE_INSTALL_BINDIR} just includes a relative path and the windeploy might not find that path if it is outside of the current directory. With `CMAKE_INSTALL_PREFIX` it will be the correct install path